### PR TITLE
Adding Timelab contact info as one of the sub-orgs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -587,7 +587,7 @@ width="128"></td>
 <tr>
     <!-- Logo -->
     <td rowspan="4" class="logo">
-        <img src="http://pypy.org/image/pypy-logo2-white-background.png" 
+        <img src="http://pypy.org/image/pypy-logo2-white-background.png"
              width="300px"></td>
     <!-- Info -->
     <td><h4>PyPy</h4></td>
@@ -689,21 +689,6 @@ Splash and Frontera. (maybe 5 with dateparser) </td></tr>
 <tr>
 	<!-- Logo -->
 	<td rowspan="4" class="logo">
-		<img src="http://deeplearning.net/software/theano/_static/theano_logo_allblue_200x46.png"
-width="300"></td>
-	<!-- Info -->
-	<td><h4>Theano</h4></td>
-   <tr><td>Theano is an optimizing compiler for numpy.ndarray and scipy.sparse matrix that generate GPU code and do symbolic differentiation </td></tr>
-	<tr><td><a href="http://deeplearning.net/software/theano">Website</a> |
-      <a href="http://groups.google.com/group/theano-dev">Contact</a> |
-		<a href="https://github.com/Theano/Theano/wiki/GSoC2017">Ideas Page</a>
-      </td>
-   <tr><td colspan="2" class="good">Status: Ideas page in progress</td></tr>
-</tr>
-
-<tr>
-	<!-- Logo -->
-	<td rowspan="4" class="logo">
 		<img src="http://opensupernova.org/~wkerzend/gsoc2017/lib/exe/fetch.php?media=tardis-gsoc-2017-banner.png"
 width="300"></td>
 	<!-- Info -->
@@ -717,6 +702,34 @@ width="300"></td>
    <tr><td colspan="2" class="good">Status: Ideas page finished</td></tr>
 </tr>
 
+
+<tr>
+	<!-- Logo -->
+	<td rowspan="4" class="logo">
+		<img src="http://deeplearning.net/software/theano/_static/theano_logo_allblue_200x46.png"
+width="300"></td>
+	<!-- Info -->
+	<td><h4>Theano</h4></td>
+   <tr><td>Theano is an optimizing compiler for numpy.ndarray and scipy.sparse matrix that generate GPU code and do symbolic differentiation </td></tr>
+	<tr><td><a href="http://deeplearning.net/software/theano">Website</a> |
+      <a href="http://groups.google.com/group/theano-dev">Contact</a> |
+		<a href="https://github.com/Theano/Theano/wiki/GSoC2017">Ideas Page</a>
+      </td>
+   <tr><td colspan="2" class="good">Status: Ideas page in progress</td></tr>
+</tr>
+
+
+<tr>
+	<td rowspan="4" class="logo">
+		<img src="http://timelabtechnologies.com/img/logo_300x76.PNG"></td>
+	<td><h4>Timelab</h4></td>
+	<tr><td>Time series analysis for astronomy, to study the variability in black hole emission.</td></tr>
+	<tr><td><a href="http://timelabtechnologies.com/">Website</a> |
+		<a href="mailto:gsoc@timelabtechnologies.com">gsoc@timelabtechnologies.com</a> |
+		<a href="http://stingray-slack.herokuapp.com/">Our Slack channel</a> |
+		<a href="http://timelabtechnologies.com/ideas.html">Ideas Page</a></td>
+   <tr><td colspan="2" class="good">Status: Ideas page finished</td></tr>
+</tr>
 
 
 </table>


### PR DESCRIPTION
Upon request from Timelab to be a sub-org of the PSF for GSoC 2017 (email from Simone Migliari to Terri Oda on Feb 28), Terri asked us to add our contacts: I have added Timelab as one of the sub-org to the index.html.

I also took the liberty to swap TARDIS and Theano since they weren't in alphabetical order, I hope that's ok.

Thanks!