### PR TITLE
Use Gitter as MNE-Python's contact information

### DIFF
--- a/index.html
+++ b/index.html
@@ -539,7 +539,7 @@ width="256"></td>
   <tr>
   <td>
     <a href="http://martinos.org/mne/">Website</a> |
-    <a href="http://github.com/mne-tools/mne-python">Contact</a> |
+    <a href="https://gitter.im/mne-tools/mne-python">Contact</a> |
     <a href="https://github.com/mne-tools/mne-python/wiki/GSOC-Ideas">Ideas Page</a>
    </td>
    <tr><td colspan="2" class="good">Status: Ideas page in progress</td></tr>


### PR DESCRIPTION
Currently the contact link for MNE-Python sends you to the github page. The project also has a mailing list, but that appears to be for analysis rather than development. 