### PR TITLE
Typo error in a link under Students information

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@ Questions</a> (FAQ) which does in fact answer 99% of the questions we get on
 the main GSoC IRC channel.</li>
 
 <li>Python's <a
-href="https://wiki.python.org/moin/SummerOfCode/Expectations">SummerOfCode/Expectations</a> also talks about what Python in particular
+href="https://wiki.python.org/moin/Summer of Code/Expectations">SummerOfCode/Expectations</a> also talks about what Python in particular
 is looking for in its students.</li>
 
 <li>Python's <a


### PR DESCRIPTION
Under Students information.