### PR TITLE
Editing the email id for mentor contact

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,8 +139,8 @@ long, stay as long as you can and then send email to the mailing list instead
 so mentors have some way to reach you.  We try to answer emails within 48h.</p>
 
 <p><strong>For mentors</strong>: All the gsoc admins can be reached at
-gsoc-admins(at)python(dot)org if you have questions about participating.
-(Students should email gsoc-general(at)python.org with all of their
+gsoc-admins@python.org if you have questions about participating.
+(Students should email gsoc-general@python.org with all of their
 questions, unless they are of a sensitive personal nature.)
 
 


### PR DESCRIPTION
@ is used instead of (at) and . for (dot) while mentioning the email address for contacting mentors