### PR TITLE
add statsmodels info

### DIFF
--- a/index.html
+++ b/index.html
@@ -576,6 +576,30 @@
             <hr>
             <!-- End template -->
 
+            <!-- Start Template -->
+            <div class="pure-u-1 pure-u-md-1-1 pure-u-lg-1-1">
+                <div class="pure-g">
+                    <div class="pure-u-1 pure-u-md-1-2">
+                        <img src="http://www.statsmodels.org/devel/_static/statsmodels_hybi_favico.ico" />
+                    </div>
+                    <div class="pure-u-1 pure-u-md-1-2">
+                        <h2 style="text-align: center;">
+                            Statsmodels
+                        </h2>
+                    </div>
+                </div>
+        <p>Statsmodels.</p>
+        <p>Statsmodels is a general purpose Python package for data analysis,
+statistics and econometrics</p>
+                <div class="pure-g" style="text-align: center;">
+                    <div class="pure-u-1 pure-u-md-1-5"><p><a href="http://www.statsmodels.org/devel/">Website</a></p></div>
+                    <div class="pure-u-1 pure-u-md-1-5"><p><a href="http://groups.google.com/group/pystatsmodels">mailing list</a></p></div>
+                    <div class="pure-u-1 pure-u-md-1-5"><p><a href="https://github.com/statsmodels/statsmodels/wiki/Google-Summer-of-Code-2019">Ideas</div>
+                </div>
+            </div>
+            <hr>
+            <!-- End template -->
+
             </div>
             <!-- Ideas -->
             <a name="contact"></a>


### PR DESCRIPTION
add statsmodels as sub-org

not quite finished yet,
I will extend the description this year.

For our ideas page:

We are only looking at advanced topics this year, i.e. topics that require strong econometrics and statistics background.
Some ideas still need more details.

