### PR TITLE
add final checkin to list 

### DIFF
--- a/deadlines.html
+++ b/deadlines.html
@@ -47,8 +47,8 @@
             height: 0;
             overflow: hidden;
         }
-        .responsive-iframe-container iframe,   
-        .vresponsive-iframe-container object,  
+        .responsive-iframe-container iframe,
+        .vresponsive-iframe-container object,
         .vresponsive-iframe-container embed {
             position: absolute;
             top: 0;
@@ -130,6 +130,7 @@
                     <li>August 5 - 5th blog post</li>
                     <li>August 12 - 6th checkin</li>
                     <li>August 19 - 6th (and final!) blog post (Final work submissions happen this week) </li>
+                    <li>August 26 - 7th (and final!) checkin</li>
                 </ul>
 
                 <div class="responsive-iframe-container big-container">


### PR DESCRIPTION
According to the [calendar](https://python-gsoc.org/deadlines.html) (see screenshot below), there was a final "checkin" blogpost due on the 26th of August. This was missing from the list and is added with this PR.

# Calendar:

![image](https://user-images.githubusercontent.com/9084751/62025835-8b9f4000-b1d9-11e9-8a39-aa61ff904479.png)

# However, missing from list (ends with 19th):

![image](https://user-images.githubusercontent.com/9084751/62025919-c99c6400-b1d9-11e9-8433-05faeb4d22e9.png)
