### PR TITLE
Resolve content is null in ui.js

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -3,7 +3,7 @@
     var layout   = document.getElementById('layout'),
         menu     = document.getElementById('menu'),
         menuLink = document.getElementById('menuLink'),
-        content  = document.getElementById('main');
+        content  = document.getElementsByClassName('main');
 
     function toggleClass(element, className) {
         var classes = element.className.split(/\s+/),
@@ -43,4 +43,4 @@
         }
     };
 
-}(this, this.document));
+})(this, this.document);


### PR DESCRIPTION
Fixes #92 


There is no code with an id of `main` in `index.html` so `getElementById` is returning `null`. Replacing it with `getElementsByClassName` resolves the error. Also the closing bracket of the IIFE was wrongly placed in `ui.js`. I have resolved that. Thanks.
