### PR TITLE
Update chat link in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,7 +369,7 @@
                     </div>
                     
                         <div class="pure-u-1 pure-u-md-1-1" style="text-align: center;">
-                            <p><a href="#python-gsoc">Chat</a></p>
+                            <p><a href="#https://riot.im/app/#/room/#python-gsoc:matrix.python-gsoc.org">Chat</a></p>
                         </div>
                     
                     <div class="pure-u-1 pure-u-md-1">


### PR DESCRIPTION
The "Chat" link initially redirected to #python-gsoc
I have changed it to the riot chat room link which is 
https://riot.im/app/#/room/#python-gsoc:matrix.python-gsoc.org 