### PR TITLE
Fixed small typo in GSoC 2020 page

### DIFF
--- a/index.html
+++ b/index.html
@@ -694,7 +694,7 @@
                     <a href="https://github.com/scrapy/scrapy">Scrapy</a>,
                     <a href="https://github.com/scrapinghub/splash">Splash</a>,
                     <a href="https://github.com/TeamHG-Memex/eli5">ELI5</a>, and
-                    <a href="https://github.com/scrapinghub/dateparser">Daterapser</a>.
+                    <a href="https://github.com/scrapinghub/dateparser">Dateparser</a>.
                 </p>
 
                 <div class="pure-g" style="text-align: center;">


### PR DESCRIPTION
Corrected typo for Scrapinghub project 'Dateparser'.