### PR TITLE
Add links to compiler options idea

### DIFF
--- a/ideas.html
+++ b/ideas.html
@@ -685,9 +685,9 @@
 					<br/>
 					Task outline:<br/>
 					<ul>
-						<li>There's already a list of compiler option candidates to adopt, use that as the initial list.</li>
+						<li>There's already a <a href="https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++">list of compiler option candidates to adopt</a>, use that as the initial list.</li>
 						<li>Do some performance evaluation for how each compiler option affects performance (using CPython's existing performance suite). Report back on the performance impact of enabling each option.</li>
-						<li>Implement a small custom tool (proposed in the existing issue) that allows ignoring existing violations of compiler options while preventing future violations. At this point we've achieved a lot of value, all future CPython contributions will have these compiler options applied.</li>
+						<li>Implement a small custom tool (proposed in the <a href="https://github.com/python/cpython/issues/112301">existing issue</a>) that allows ignoring existing violations of compiler options while preventing future violations. At this point we've achieved a lot of value, all future CPython contributions will have these compiler options applied.</li>
 						<li>After the tooling is integrated, fill the rest of the project time by remediating known issues.</li>
 					</ul>
 				</li>


### PR DESCRIPTION
Noticed that the idea is missing relevant links that would help contributors gain more context without emailing mentors. cc @warthog9 